### PR TITLE
docs(release): add 1.0.0 production notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## 1.0.0 (2025-12-25)
+
+### Highlights
+
+- Introduces a hardened, merge-blocking CI gate for pull requests.
+- Adds a structured branch promotion flow: `develop` → `release` → `main`.
+- Establishes Vitest + Testing Library setup with coverage support and test quality improvements.
+
+### CI/CD
+
+- Pins GitHub Actions to full commit SHAs for supply-chain hardening.
+- Adds a single PR gate workflow with conditional validation by base branch.
+- Integrates SonarCloud scanning (with quality gate waiting on `develop`).
+- Adds Vercel preview deploy + PR comment in the `develop` PR flow.
+
+### Testing
+
+- Adds/expands unit tests across atoms/molecules and improves assertions to satisfy static analysis.
+- Sets up Vitest environment mocks (e.g., observers, matchMedia).
+
+### App/Architecture
+
+- Next.js App Router structure with page modules under `src/views/pages/**`.
+- Centralizes header/menu state via context and hooks.
+
+### Tooling
+
+- Adds/updates linting + formatting rules and ignores CI definitions where desired.
+- Keeps dependency management aligned with pnpm and project engine constraints.

--- a/docs/releases/1.0.0.md
+++ b/docs/releases/1.0.0.md
@@ -1,0 +1,60 @@
+# Release 1.0.0 — Pase a producción
+
+Fecha: 2025-12-25
+
+## Objetivo
+
+Publicar a producción el estado validado en `release` promoviendo `release` → `main`.
+
+## Alcance (qué se está publicando)
+
+Esta versión consolida el setup del proyecto para operar con un flujo GitFlow, validaciones automatizadas y calidad consistente.
+
+Incluye (alto nivel):
+
+- CI merge-blocking (PR Gate) con estrategia por rama (`develop`/`release`/`main`).
+- Hardening de GitHub Actions (pin por SHA) + Dependabot agrupado.
+- Setup de tests (Vitest + Testing Library) y refactors para cumplir reglas de calidad.
+- Ajustes de arquitectura (App Router + vistas) y componentes.
+
+## Pre-requisitos
+
+- La rama `release` debe estar verde y contener el merge `develop → release`.
+- Debe existir PR `release → main` y pasar los checks configurados para `main`.
+
+## Validación esperada (antes del merge a `main`)
+
+Según la política actual, en PRs con base `main` corren:
+
+- `lint`
+- `format:check`
+
+Nota: el set completo (typecheck + tests + coverage + Sonar + Vercel preview) se ejecuta en PRs a `develop`, y un set intermedio corre en PRs a `release`.
+
+## Plan de despliegue
+
+1. Crear PR `release` → `main` con notas de release.
+2. Revisar el PR (cambios, workflows, configuración, y artefactos relevantes).
+3. Confirmar que los checks obligatorios estén en verde.
+4. Hacer merge a `main`.
+
+## Post-merge (después de publicar)
+
+Checklist mínima:
+
+- Verificar build/deploy de producción (Vercel/hosting) asociado a `main`.
+- Smoke test manual: cargar home, navegación/menú, slider, footer.
+- Verificar que no existan errores en consola y que no haya 404s en assets críticos.
+
+## Rollback
+
+Opciones (de menor a mayor impacto):
+
+- Revert del merge commit en `main` si el problema es introducido por este pase.
+- Re-deploy del commit/tag previo estable si el proveedor lo permite.
+
+## Referencias
+
+- Changelog: ver `CHANGELOG.md`.
+- Promoción previa: PR `develop → release`.
+- Pase actual: PR `release → main`.


### PR DESCRIPTION
## Objetivo
Versionar y centralizar la documentación del pase a producción `release → main` para la versión **1.0.0**.

## Qué se agrega
- `CHANGELOG.md` con entry **1.0.0**.
- `docs/releases/1.0.0.md` con:
  - objetivo y alcance,
  - validaciones esperadas por rama,
  - plan de despliegue,
  - checklist post-merge,
  - rollback.

## Por qué ahora
La rama `release` está protegida y no permite pushes directos, así que esta documentación entra vía PR antes del pase final a `main`.
