### PR TITLE
refactor(web): remove type prefix naming

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,236 @@
+# Pull Request
+
+## 🧾 Summary (required)
+
+<!-- Even for tiny PRs, fill this out. Keep it short but explicit. -->
+
+- **What:**
+- **Why:**
+- **Impact / User-facing:**
+
+---
+
+## 🏷️ Title format (required)
+
+Use Conventional Commits in the PR title:
+
+Recommended (when an issue exists):
+
+`<type>(<scope>): <short description> (#<issue>)`
+
+Allowed (when there is no issue):
+
+`<type>(<scope>): <short description>`
+
+Notes:
+
+- Use lowercase for `type` and `scope`.
+- Keep the description imperative and short (≤ 72 chars).
+- Add `!` for breaking changes.
+- `(#<issue>)` is recommended when an issue exists.
+
+---
+
+## 🧩 Type of change
+
+<!-- Mark one main type (or a couple if truly needed) -->
+
+- [ ] feat (new feature)
+- [ ] fix (bug fix)
+- [ ] refactor (no functional change)
+- [ ] style (formatting, lint, UI polish)
+- [ ] perf (performance improvement)
+- [ ] docs (documentation)
+- [ ] test (tests only)
+- [ ] build (build/dependencies)
+- [ ] ci (pipelines/automation)
+- [ ] chore (internal/maintenance)
+- [ ] revert
+
+---
+
+## 🧭 Scope
+
+<!-- Affected areas/modules -->
+
+- [ ] web
+- [ ] api
+- [ ] ui
+- [ ] auth
+- [ ] seo
+- [ ] i18n
+- [ ] config
+- [ ] infra
+- [ ] other: **\*\*\*\***\_\_**\*\*\*\***
+
+---
+
+## 🔗 Links (when applicable)
+
+| Item              | Link     |
+| ----------------- | -------- |
+| Issue             | Closes # |
+| Related PRs       | Refs #   |
+| Vercel Preview    |          |
+| SonarCloud Report |          |
+| Docs/Spec         |          |
+
+---
+
+## ✅ Changes (required)
+
+<!-- Prefer a table so reviewers can scan quickly. -->
+
+| Area | Path(s) | Change | Risk         | Notes |
+| ---- | ------- | ------ | ------------ | ----- |
+|      |         |        | low/med/high |       |
+
+---
+
+## 🧪 How to test (required)
+
+<!-- Use "N/A" only when truly not applicable. -->
+
+### Steps
+
+1.
+2.
+
+### Commands (required for code changes)
+
+<!--
+Required when the PR changes application code (typically `src/**`).
+If the PR only changes docs/CI/config and does not affect `src/**`, mark this section as N/A.
+-->
+
+| Check              | Command              | Result  |
+| ------------------ | -------------------- | ------- |
+| Typecheck + lint   | `pnpm validate`      | ✅ / ❌ |
+| Tests              | `pnpm test`          | ✅ / ❌ |
+| Coverage (min 90%) | `pnpm test:coverage` | ✅ / ❌ |
+
+### Coverage summary (required for code changes)
+
+<!--
+Required when the PR changes application code (typically `src/**`).
+If the PR does not touch `src/**`, write: N/A.
+-->
+
+<!-- Paste the summary numbers from the report (or link the CI job/artifact). -->
+
+| Metric     | %   |
+| ---------- | --- |
+| Lines      |     |
+| Functions  |     |
+| Branches   |     |
+| Statements |     |
+
+Policy: minimum coverage **≥ 90%** (target 100% when feasible).
+
+---
+
+## 👥 Authors / Contributors (optional)
+
+<!-- GitHub already shows the PR author. Use this for pair/mob programming or multiple contributors. -->
+
+- Author: @
+- Contributors: @ @
+
+---
+
+## 📸 Screenshots / Recordings (UI changes)
+
+<!-- Drag and drop images or videos here. Add before/after if relevant. -->
+
+---
+
+## 🗂️ Affected structure (when useful)
+
+<!-- If you added/moved folders/files, include a small tree. -->
+
+```text
+src/
+ ...
+```
+
+---
+
+## 💻 Code excerpts (optional)
+
+<!-- Paste a small snippet when it helps reviewers. Keep it short. -->
+
+```ts
+// example
+```
+
+---
+
+## ⚠️ Breaking Changes
+
+- [ ] No
+- [ ] Yes
+
+If **Yes**, describe clearly:
+
+```text
+What breaks?
+Who is affected?
+What migration or action is required?
+```
+
+---
+
+## 🚀 Performance impact
+
+- [ ] No impact
+- [ ] Improved
+- [ ] Potential regression
+
+Details:
+
+<!-- Bundle size, metrics, benchmarks, Lighthouse, etc -->
+
+---
+
+## 🔐 Security considerations
+
+- [ ] No impact
+- [ ] Yes
+
+If **Yes**, explain:
+
+<!-- auth, data exposure, permissions, secrets -->
+
+---
+
+## ♿ Accessibility (UI changes)
+
+- [ ] Not applicable
+- [ ] Verified (keyboard, contrast, aria)
+- [ ] Needs review
+
+---
+
+## 🧪 Tests
+
+- [ ] Not required
+- [ ] Existing tests updated
+- [ ] New tests added
+
+Details:
+
+<!-- unit / integration / e2e -->
+
+---
+
+## ✅ Checklist
+
+- [ ] PR title follows Conventional Commits
+- [ ] Issue reference included (`#ID`) when applicable (recommended)
+- [ ] Code follows project standards
+- [ ] TypeScript strict mode respected
+- [ ] No `any` types introduced
+- [ ] No `console.*` statements or `debugger` left in code
+- [ ] No empty `catch {}` blocks (errors handled or rethrown)
+- [ ] Lint and tests are passing
+- [ ] Documentation updated (if needed)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,106 @@
 # Copilot Instructions (Navike21 Web)
 
+## Commit & PR conventions (Conventional Commits)
+
+When creating commits and PRs for this repository, follow this format:
+
+Recommended format (when an issue exists):
+
+`<type>(<scope>): <short description> (#<issue>)`
+
+Allowed format (when there is no issue):
+
+`<type>(<scope>): <short description>`
+
+Rules:
+
+- `type` and `scope` are lowercase.
+- `short description` is imperative, present tense, and concise (ideally ≤ 72 chars).
+- `(#<issue>)` is recommended when an issue exists; omit it if there is no issue.
+- Use `!` for breaking changes: `feat(auth)!: change token format (#88)`.
+- Avoid vague titles like "Update stuff", "Fix bug", "WIP".
+
+Allowed `type` values:
+
+- `feat` | `fix` | `docs` | `style` | `refactor` | `perf` | `test` | `build` | `ci` | `chore` | `revert`
+
+Recommended `scope` values:
+
+- `web` | `api` | `ui` | `auth` | `seo` | `i18n` | `config` | `infra`
+
+Examples (good):
+
+- `feat(web): add multilingual homepage (#42)`
+- `fix(api): handle expired tokens (#57)`
+- `refactor(ui): simplify navbar structure (#63)`
+- `docs(config): update setup instructions (#71)`
+- `chore(build): update next.js to latest (#90)`
+
+Examples (bad):
+
+- `Update stuff`
+- `Fix bug`
+- `Add feature`
+- `WIP login`
+
+## GitFlow / branching policy
+
+Branch chain (promotion):
+
+`feature/*` → `develop` → `release` → `main`
+
+Goals:
+
+- Keep `release` and `main` aligned (production parity).
+- Keep `develop` always releasable (or safe via feature flags).
+- Avoid cherry-picks for normal releases.
+
+Rules for merging into `develop`:
+
+- Do NOT merge incomplete work into `develop`.
+- Exception: work-in-progress is allowed only if it is fully protected by a feature flag and defaults to OFF in `release`/`main`.
+- Even behind a flag, code must pass checks (typecheck/lint/tests) and should not degrade coverage thresholds.
+
+PR validation scope (recommended):
+
+- If a PR changes application code (typically `src/**`), it must include QA validation + tests + coverage.
+- If a PR only changes docs/CI/config (no `src/**` changes), QA/coverage can be marked as `N/A` (still keep lint/format/typecheck as appropriate).
+
+Feature flags (recommended):
+
+- Prefer environment-controlled flags (example: `NEXT_PUBLIC_FEATURE_X=false`).
+- The code path must be safe when the flag is OFF.
+
+Keeping feature branches up to date (recommended):
+
+- If a `feature/*` branch is behind `develop`, prefer rebasing to reduce merge noise and conflicts.
+- Typical workflow:
+  - `git fetch origin`
+  - `git rebase origin/develop`
+  - Resolve conflicts, then `git push --force-with-lease`
+
+Promotion to `release` and `main` (no cherry-pick):
+
+- QA validates via PR preview on `feature/* → develop`.
+- When the set of changes in `develop` is approved for release, open a PR:
+  - `develop → release`
+  - QA validates again on `release` (final staging validation).
+- When `release` is approved, open a PR:
+  - `release → main`
+  - Tag the release on `main` (e.g., `vX.Y.Z`) and publish GitHub Release notes.
+
+Keeping `release` and `main` equal:
+
+- `main` must only receive changes via PRs from `release`.
+- If anything advances `main` (hotfix, release merge), immediately sync back with PRs so branches remain aligned:
+  - `main → release` (if needed)
+  - `release → develop` (so fixes are not lost)
+
+When multiple teams are working:
+
+- Either keep `develop` strict (only fully complete work), OR allow merging behind feature flags.
+- This prevents `release` from being “corrupted” when promoting `develop → release`.
+
 ## Big picture
 
 - Next.js App Router: route files in `src/app/**` are thin wrappers that render view modules from `src/views/pages/**` (example: `src/app/page.tsx` → `src/views/pages/Home/Home.tsx`).
@@ -10,6 +111,52 @@
 
 - Prefer TS path aliases from `tsconfig.json`: `@Components`, `@Pages`, `@Context`, `@I18n`, `@Helpers`, `@Styles`, etc.
 - Global styles are under `src/libs/styles/**` and imported via `@Styles/globals.css` in `src/app/layout.tsx`.
+
+## TypeScript standards (no `any`)
+
+This is a Next.js + TypeScript + Tailwind project. Code must follow modern TS best practices.
+
+Hard rules:
+
+- Do NOT introduce `any` (including `any[]`, `Record<string, any>`, and `as any`).
+- Do NOT suggest or add `// @ts-ignore` or `// @ts-nocheck`.
+- Do NOT disable lint rules to allow unsafe typing.
+
+Preferred alternatives:
+
+- Use `unknown` instead of `any`, then narrow via type guards.
+- Prefer generics, discriminated unions, and `satisfies` for safer inference.
+- When dealing with untyped data (API/JSON), parse + validate and return typed results.
+- Use `type` imports (`import type { ... }`) where applicable.
+
+React/Next.js typing guidance:
+
+- Prefer explicit component prop types and avoid implicit `any` in callbacks.
+- When interacting with DOM APIs, type the element refs and events properly.
+- Keep server/client boundaries clear (App Router): avoid leaking server-only types into client components.
+
+Tailwind guidance:
+
+- Prefer Tailwind utility classes and existing tokens; avoid introducing ad-hoc styles.
+- Keep `className` composition typed and readable (e.g., `clsx`).
+
+## Logging & error handling
+
+Logging policy:
+
+- Do NOT leave `console.*` or `debugger` statements in committed code.
+- If you need diagnostics, prefer:
+  - returning a typed error result (or a safe fallback) and letting the UI render a friendly message, or
+  - throwing and relying on Next.js error boundaries where appropriate.
+
+Try/catch policy:
+
+- Avoid `try/catch` unless you can _meaningfully_ handle the error (recover, fallback, translate to user-safe message, or rethrow with context).
+- Never swallow errors silently: no empty `catch {}` blocks.
+- Treat caught errors as `unknown` and narrow before using:
+  - `catch (err: unknown) { ... }` (preferred), then narrow via type guards.
+  - For Promise chains, `.catch((err: unknown) => { ... })`.
+- If you cannot recover, rethrow (optionally wrap) and let a higher-level boundary handle it.
 
 ## State + cross-component behavior
 
@@ -26,5 +173,5 @@
 
 - Local: `pnpm dev` (Turbopack), `pnpm build`, `pnpm start`, `pnpm validate` (typecheck+lint), `pnpm format`.
 - Tests: Vitest + Testing Library (`pnpm test`, `pnpm test:coverage`). Environment/mocks live in `vitest.setup.ts` (e.g., `IntersectionObserver`, `ResizeObserver`, `matchMedia`).
-- Coverage: thresholds are 70% and several directories are excluded (see `vitest.config.ts`).
+- Coverage: minimum thresholds are 90% (target 100% when feasible) and several directories are excluded (see `vitest.config.ts`).
 - CI (GitHub Actions) runs `typecheck`, `lint`, `format:check`; release also runs `build:ci` (see `.github/workflows/*.yml`).

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ Navike21 Web es una aplicación web moderna con **Next.js (App Router)**, arquit
 
 ## 🧰 Tech Stack (actual)
 
-| Área | Stack |
-| --- | --- |
-| Framework | Next.js 16 (App Router) |
-| UI | React 19 + Tailwind CSS (`src/libs/styles/`) |
-| Animación/scroll | `motion` + `lenis` (LayoutScroll) |
-| Testing | Vitest + Testing Library |
-| Tooling | TypeScript + ESLint + Prettier + pnpm |
+| Área             | Stack                                        |
+| ---------------- | -------------------------------------------- |
+| Framework        | Next.js 16 (App Router)                      |
+| UI               | React 19 + Tailwind CSS (`src/libs/styles/`) |
+| Animación/scroll | `motion` + `lenis` (LayoutScroll)            |
+| Testing          | Vitest + Testing Library                     |
+| Tooling          | TypeScript + ESLint + Prettier + pnpm        |
 
 ## 📦 Qué contiene el proyecto (detalle)
 
@@ -71,21 +71,21 @@ pnpm dev
 
 ### Scripts
 
-| Acción | Comando |
-| --- | --- |
-| Instalar dependencias | `pnpm install` |
-| Levantar dev server | `pnpm dev` |
-| Build producción | `pnpm build` |
-| Start producción | `pnpm start` |
-| Typecheck | `pnpm typecheck` |
-| Lint | `pnpm lint` |
-| Format | `pnpm format` |
+| Acción                | Comando          |
+| --------------------- | ---------------- |
+| Instalar dependencias | `pnpm install`   |
+| Levantar dev server   | `pnpm dev`       |
+| Build producción      | `pnpm build`     |
+| Start producción      | `pnpm start`     |
+| Typecheck             | `pnpm typecheck` |
+| Lint                  | `pnpm lint`      |
+| Format                | `pnpm format`    |
 
 ## 🧪 Testing
 
-| Acción | Comando |
-| --- | --- |
-| Tests | `pnpm test` |
+| Acción   | Comando              |
+| -------- | -------------------- |
+| Tests    | `pnpm test`          |
 | Coverage | `pnpm test:coverage` |
 
 Notas:
@@ -97,11 +97,11 @@ Notas:
 
 ### PR Gate (qué corre según la base)
 
-| Base del PR | Checks |
-| --- | --- |
-| `develop` | typecheck · lint · prettier · tests (coverage) · SonarCloud (quality gate) · Vercel preview/comment |
-| `release` | typecheck · lint · prettier · tests (sin coverage) |
-| `main` | lint · format:check |
+| Base del PR | Checks                                                                                              |
+| ----------- | --------------------------------------------------------------------------------------------------- |
+| `develop`   | typecheck · lint · prettier · tests (coverage) · SonarCloud (quality gate) · Vercel preview/comment |
+| `release`   | typecheck · lint · prettier · tests (sin coverage)                                                  |
+| `main`      | lint · format:check                                                                                 |
 
 ### Supply chain & deps
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -65,6 +65,7 @@ export default [
         'error',
         { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }
       ],
+      '@typescript-eslint/use-unknown-in-catch-callback-variable': 'error',
       'react-hooks/rules-of-hooks': 'error',
       'react-hooks/exhaustive-deps': 'warn',
       'react/self-closing-comp': ['error', { component: true, html: true }],
@@ -75,8 +76,9 @@ export default [
       'jsx-a11y/alt-text': 'warn',
       semi: ['error', 'never'],
       quotes: ['error', 'single', { avoidEscape: true }],
-      'no-console': 'warn',
-      'no-debugger': 'error'
+      'no-console': 'error',
+      'no-debugger': 'error',
+      'no-empty': ['error', { allowEmptyCatch: false }]
     }
   },
   {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "navike21-web",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "packageManager": "pnpm@9.15.0",
   "engines": {

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { useEffect } from 'react'
 import { Button } from '@Components/atoms'
 
 interface ErrorProps {
@@ -8,15 +7,7 @@ interface ErrorProps {
   reset: () => void
 }
 
-export default function ErrorBoundary({ error, reset }: Readonly<ErrorProps>) {
-  useEffect(() => {
-    // Log error to console in development
-    if (process.env.NODE_ENV === 'development') {
-      // eslint-disable-next-line no-console
-      console.error('Application error:', error)
-    }
-  }, [error])
-
+export default function ErrorBoundary({ reset }: Readonly<ErrorProps>) {
   return (
     <div className="flex min-h-screen flex-col items-center justify-center gap-6 px-4">
       <div className="text-center">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,11 +11,11 @@ export const metadata: Metadata = {
     'Navike21 delivers modern web applications, custom software, and innovative digital solutions to boost your business with cutting-edge technology.'
 }
 
-interface IRootLayoutProps {
+interface RootLayoutProps {
   children: ReactNode
 }
 
-export default function RootLayout({ children }: Readonly<IRootLayoutProps>) {
+export default function RootLayout({ children }: Readonly<RootLayoutProps>) {
   return (
     <html lang="es">
       <body

--- a/src/libs/components/atoms/Avatar/Avatar.hooks.ts
+++ b/src/libs/components/atoms/Avatar/Avatar.hooks.ts
@@ -1,4 +1,4 @@
-import type { IAvatarProps } from './Avatar.types'
+import type { AvatarProps } from './Avatar.types'
 
 const SIZE_MAP = {
   sm: 'min-w-8 h-8 text-sm ',
@@ -26,12 +26,12 @@ const STATUS_SIZE_MAP = {
   lg: 'w-4 h-4'
 } as const
 
-export const useAvatar = ({ name, alt }: IAvatarProps) => {
+export const useAvatar = ({ name, alt }: Pick<AvatarProps, 'name' | 'alt'>) => {
   const initials = name
     ? name
         .trim()
         .split(/\s+/)
-        .map(n => n[0]?.toUpperCase())
+        .map((word: string) => word[0]?.toUpperCase())
         .slice(0, 2)
         .join('')
     : '?'

--- a/src/libs/components/atoms/Avatar/Avatar.tsx
+++ b/src/libs/components/atoms/Avatar/Avatar.tsx
@@ -2,7 +2,7 @@
 
 import clsx from 'clsx'
 import { memo } from 'react'
-import type { IAvatarProps } from './Avatar.types'
+import type { AvatarProps } from './Avatar.types'
 import Image from 'next/image'
 import { useAvatar } from './Avatar.hooks'
 
@@ -14,7 +14,7 @@ export const Avatar = memo(function Avatar({
   className,
   title,
   ...props
-}: Readonly<IAvatarProps>) {
+}: Readonly<AvatarProps>) {
   const {
     sizeMap,
     statusColorMap,

--- a/src/libs/components/atoms/Avatar/Avatar.types.ts
+++ b/src/libs/components/atoms/Avatar/Avatar.types.ts
@@ -1,14 +1,14 @@
 import type { StaticImageData } from 'next/image'
 
-export type TAvatarSize = 'sm' | 'md' | 'lg'
-export type TAvatarStatus = 'online' | 'offline' | 'busy' | 'away' | 'none'
+export type AvatarSize = 'sm' | 'md' | 'lg'
+export type AvatarStatus = 'online' | 'offline' | 'busy' | 'away' | 'none'
 
-export interface IAvatarProps {
+export interface AvatarProps {
   src?: string | StaticImageData
   alt?: string
   name?: string
-  size?: TAvatarSize
-  status?: TAvatarStatus
+  size?: AvatarSize
+  status?: AvatarStatus
   className?: string
   title?: string
 }

--- a/src/libs/components/atoms/Button/Button.tsx
+++ b/src/libs/components/atoms/Button/Button.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx'
 import { IconComponent } from '../IconComponent'
-import { type IButtonProps } from '@Types/buttonProps'
+import { type ButtonProps } from '@Types/buttonProps'
 
 export const Button = ({
   variant = 'primary',
@@ -9,7 +9,7 @@ export const Button = ({
   size = 'medium',
   icon,
   ...props
-}: Readonly<IButtonProps>) => {
+}: Readonly<ButtonProps>) => {
   return (
     <button
       className={clsx(

--- a/src/libs/components/atoms/Card/Card.tsx
+++ b/src/libs/components/atoms/Card/Card.tsx
@@ -1,13 +1,9 @@
 import clsx from 'clsx'
 import { IconComponent } from '../IconComponent'
 import Link from 'next/link'
-import type {
-  ICardProps,
-  IItemCardProps,
-  IItemLinkCardProps
-} from './Card.types'
+import type { CardProps, ItemCardProps, ItemLinkCardProps } from './Card.types'
 
-export const Card = ({ children, showLine, className }: ICardProps) => (
+export const Card = ({ children, showLine, className }: CardProps) => (
   <div
     className={clsx(
       'bg-white transition-all duration-500 group h-full',
@@ -35,7 +31,7 @@ export const ItemCard = ({
   icon,
   className,
   ...props
-}: IItemCardProps) => (
+}: ItemCardProps) => (
   <Card className={clsx('group aspect-auto', className)} showLine {...props}>
     <div className={clsx('flex flex-col items-center gap-5 h-full')}>
       {icon && (
@@ -67,7 +63,7 @@ export const ItemCard = ({
   </Card>
 )
 
-export const ItemLinkCard = ({ href, ...props }: IItemLinkCardProps) => (
+export const ItemLinkCard = ({ href, ...props }: ItemLinkCardProps) => (
   <Link href={href} className="w-full">
     <ItemCard {...props} />
   </Link>

--- a/src/libs/components/atoms/Card/Card.types.ts
+++ b/src/libs/components/atoms/Card/Card.types.ts
@@ -1,19 +1,19 @@
-import type { TIconName } from '@Types/icons'
+import type { IconName } from '@Types/icons'
 import type { ReactNode } from 'react'
 
-export interface ICardProps {
+export interface CardProps {
   children?: ReactNode
   showLine?: boolean
   className?: string
 }
 
-export interface IItemCardProps extends ICardProps {
+export interface ItemCardProps extends CardProps {
   description?: string
   title?: string
-  icon?: TIconName
+  icon?: IconName
   className?: string
 }
 
-export interface IItemLinkCardProps extends IItemCardProps {
+export interface ItemLinkCardProps extends ItemCardProps {
   href: string
 }

--- a/src/libs/components/atoms/Container/Container.tsx
+++ b/src/libs/components/atoms/Container/Container.tsx
@@ -1,12 +1,12 @@
 import clsx from 'clsx'
 import { type ReactNode } from 'react'
 
-interface IContainer {
+interface ContainerProps {
   children: ReactNode
   className?: string
 }
 
-export const Container = ({ children, className }: IContainer) => (
+export const Container = ({ children, className }: ContainerProps) => (
   <div className={clsx('container max-w-7xl mx-auto w-[80%]', className)}>
     {children}
   </div>

--- a/src/libs/components/atoms/IconComponent/IconComponent.tsx
+++ b/src/libs/components/atoms/IconComponent/IconComponent.tsx
@@ -1,8 +1,8 @@
-import { type IIconProps } from '@Types/icons'
+import { type IconProps } from '@Types/icons'
 import clsx from 'clsx'
 import * as RemixIcons from '@remixicon/react'
 
-export const IconComponent = ({ icon, className }: IIconProps) => {
+export const IconComponent = ({ icon, className }: IconProps) => {
   const LucideIconComponent = RemixIcons[icon]
 
   return <LucideIconComponent className={clsx(className)} />

--- a/src/libs/components/atoms/LinkButton/LinkButton.tsx
+++ b/src/libs/components/atoms/LinkButton/LinkButton.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx'
 import { IconComponent } from '../IconComponent'
 import Link from 'next/link'
-import { type ILinkButtonProps } from '@Types/buttonProps'
+import { type LinkButtonProps } from '@Types/buttonProps'
 
 export const LinkButton = ({
   variant = 'primary',
@@ -10,7 +10,7 @@ export const LinkButton = ({
   size = 'medium',
   icon,
   ...props
-}: Readonly<ILinkButtonProps>) => {
+}: Readonly<LinkButtonProps>) => {
   return (
     <Link
       className={clsx(

--- a/src/libs/components/atoms/Logo/Logo.test.tsx
+++ b/src/libs/components/atoms/Logo/Logo.test.tsx
@@ -1,7 +1,7 @@
 import { render } from '@testing-library/react'
 import { describe, it, expect } from 'vitest'
 import { Logo } from './Logo'
-import type { TLogoColor } from './Logo'
+import type { LogoColor } from './Logo'
 
 describe('Logo component', () => {
   describe('basic rendering', () => {
@@ -129,7 +129,7 @@ describe('Logo component', () => {
     })
 
     it('should fallback to gradient for unknown color', () => {
-      const invalidColor = 'unknown' as TLogoColor
+      const invalidColor = 'unknown' as LogoColor
       const { container } = render(<Logo logoColor={invalidColor} />)
       const paths = container.querySelectorAll('path')
       const mainPath = paths[1]

--- a/src/libs/components/atoms/Logo/Logo.tsx
+++ b/src/libs/components/atoms/Logo/Logo.tsx
@@ -2,13 +2,13 @@
 
 import clsx from 'clsx'
 
-export type TLogoColor = 'white' | 'black' | 'gradient'
+export type LogoColor = 'white' | 'black' | 'gradient'
 
-export interface ILogoProps {
+export interface LogoProps {
   showText?: boolean
   size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl'
-  textColor?: TLogoColor
-  logoColor?: TLogoColor
+  textColor?: LogoColor
+  logoColor?: LogoColor
   classNameTextColor?: string
 }
 
@@ -18,7 +18,7 @@ export const Logo = ({
   textColor = 'black',
   logoColor = 'gradient',
   classNameTextColor
-}: ILogoProps) => (
+}: LogoProps) => (
   <div className={clsx('flex items-center gap-2 logo-navike21')}>
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/libs/components/atoms/MenuIcon/MenuIcon.tsx
+++ b/src/libs/components/atoms/MenuIcon/MenuIcon.tsx
@@ -3,11 +3,11 @@
 import { useHeaderContext } from '@Context/headerContext.hooks'
 import { motion, type Transition } from 'motion/react'
 
-interface IMenuIconProps {
+interface MenuIconProps {
   className?: string
 }
 
-export const MenuIcon = ({ className }: IMenuIconProps) => {
+export const MenuIcon = ({ className }: MenuIconProps) => {
   const { toggleMenu } = useHeaderContext()
   const transition: Transition = { duration: 0.5, ease: 'easeInOut' }
 

--- a/src/libs/components/atoms/ParallaxImage/ParallaxImage.tsx
+++ b/src/libs/components/atoms/ParallaxImage/ParallaxImage.tsx
@@ -5,7 +5,7 @@ import { motion, useScroll, useTransform } from 'motion/react'
 import Image, { type StaticImageData } from 'next/image'
 import clsx from 'clsx'
 
-interface IParallaxImageProps {
+interface ParallaxImageProps {
   img: StaticImageData
   alt: string
   className?: string
@@ -15,7 +15,7 @@ export const ParallaxImage = ({
   img,
   alt,
   className = 'relative'
-}: IParallaxImageProps) => {
+}: ParallaxImageProps) => {
   const ref = useRef<HTMLDivElement>(null)
 
   const { scrollYProgress } = useScroll({

--- a/src/libs/components/atoms/Title/Title.tsx
+++ b/src/libs/components/atoms/Title/Title.tsx
@@ -1,11 +1,11 @@
 import clsx from 'clsx'
 
-export interface ITitleProps {
+export interface TitleProps {
   title: string
   subTitle?: string
   className?: string
 }
-export const Title = ({ title, subTitle, className }: ITitleProps) => (
+export const Title = ({ title, subTitle, className }: TitleProps) => (
   <div
     className={clsx('title-area flex flex-col gap-5 items-center', className)}
   >

--- a/src/libs/components/atoms/clientsLogo/Almazen.tsx
+++ b/src/libs/components/atoms/clientsLogo/Almazen.tsx
@@ -1,6 +1,6 @@
-import { type ISvgProps } from '@Types/svg'
+import { type SvgProps } from '@Types/svg'
 
-export const Almazen = ({ isColor, ...props }: ISvgProps) => {
+export const Almazen = ({ isColor, ...props }: SvgProps) => {
   const fillColor = isColor ? '#ffffff' : 'currentColor'
   return (
     <svg

--- a/src/libs/components/atoms/clientsLogo/Anker.tsx
+++ b/src/libs/components/atoms/clientsLogo/Anker.tsx
@@ -1,6 +1,6 @@
-import { type ISvgProps } from '@Types/svg'
+import { type SvgProps } from '@Types/svg'
 
-export const Anker = ({ isColor, ...props }: ISvgProps) => (
+export const Anker = ({ isColor, ...props }: SvgProps) => (
   <svg
     viewBox="0 0 507 250"
     fill="none"

--- a/src/libs/components/atoms/clientsLogo/Beats.tsx
+++ b/src/libs/components/atoms/clientsLogo/Beats.tsx
@@ -1,6 +1,6 @@
-import { type ISvgProps } from '@Types/svg'
+import { type SvgProps } from '@Types/svg'
 
-export const Beats = ({ isColor, ...props }: ISvgProps) => {
+export const Beats = ({ isColor, ...props }: SvgProps) => {
   const fillColor = isColor ? '#ffffff' : 'currentColor'
   return (
     <svg

--- a/src/libs/components/atoms/clientsLogo/Carbyne.tsx
+++ b/src/libs/components/atoms/clientsLogo/Carbyne.tsx
@@ -1,6 +1,6 @@
-import { type ISvgProps } from '@Types/svg'
+import { type SvgProps } from '@Types/svg'
 
-export const Carbyne = ({ isColor, ...props }: ISvgProps) => (
+export const Carbyne = ({ isColor, ...props }: SvgProps) => (
   <svg
     viewBox="0 0 736 126"
     fill="none"

--- a/src/libs/components/atoms/clientsLogo/Circurela.tsx
+++ b/src/libs/components/atoms/clientsLogo/Circurela.tsx
@@ -1,6 +1,6 @@
-import { type ISvgProps } from '@Types/svg'
+import { type SvgProps } from '@Types/svg'
 
-export const Circurela = ({ isColor, ...props }: ISvgProps) => {
+export const Circurela = ({ isColor, ...props }: SvgProps) => {
   const fillColor = isColor ? '#ffffff' : 'currentColor'
   return (
     <svg

--- a/src/libs/components/atoms/clientsLogo/ColegioLaUnion.tsx
+++ b/src/libs/components/atoms/clientsLogo/ColegioLaUnion.tsx
@@ -1,6 +1,6 @@
-import { type ISvgProps } from '@Types/svg'
+import { type SvgProps } from '@Types/svg'
 
-export const ColegioLaUnion = ({ isColor, ...props }: ISvgProps) => {
+export const ColegioLaUnion = ({ isColor, ...props }: SvgProps) => {
   const fillColor = isColor ? '#ffffff' : 'currentColor'
   return (
     <svg

--- a/src/libs/components/atoms/clientsLogo/Eurogourmet.tsx
+++ b/src/libs/components/atoms/clientsLogo/Eurogourmet.tsx
@@ -1,6 +1,6 @@
-import { type ISvgProps } from '@Types/svg'
+import { type SvgProps } from '@Types/svg'
 
-export const EuroGourmet = ({ isColor, ...props }: ISvgProps) => {
+export const EuroGourmet = ({ isColor, ...props }: SvgProps) => {
   const fillColor = isColor ? '#ffffff' : 'currentColor'
   return (
     <svg

--- a/src/libs/components/atoms/clientsLogo/HammerBlocs.tsx
+++ b/src/libs/components/atoms/clientsLogo/HammerBlocs.tsx
@@ -1,6 +1,6 @@
-import { type ISvgProps } from '@Types/svg'
+import { type SvgProps } from '@Types/svg'
 
-export const HammerBlocs = ({ isColor, ...props }: ISvgProps) => {
+export const HammerBlocs = ({ isColor, ...props }: SvgProps) => {
   const fillColor = isColor ? '#ffffff' : 'currentColor'
   return (
     <svg

--- a/src/libs/components/atoms/clientsLogo/RkPower.tsx
+++ b/src/libs/components/atoms/clientsLogo/RkPower.tsx
@@ -1,6 +1,6 @@
-import { type ISvgProps } from '@Types/svg'
+import { type SvgProps } from '@Types/svg'
 
-export const RkPower = ({ isColor, ...props }: ISvgProps) => {
+export const RkPower = ({ isColor, ...props }: SvgProps) => {
   const fillColor = isColor ? '#12110C' : 'currentColor'
   return (
     <svg

--- a/src/libs/components/atoms/clientsLogo/TentacionesGourmet.tsx
+++ b/src/libs/components/atoms/clientsLogo/TentacionesGourmet.tsx
@@ -1,6 +1,6 @@
-import { type ISvgProps } from '@Types/svg'
+import { type SvgProps } from '@Types/svg'
 
-export const TentacionesGourmet = ({ isColor, ...props }: ISvgProps) => {
+export const TentacionesGourmet = ({ isColor, ...props }: SvgProps) => {
   const fillColor = isColor ? '#5B3C39' : 'currentColor'
   return (
     <svg

--- a/src/libs/components/molecules/Footer/Footer.test.tsx
+++ b/src/libs/components/molecules/Footer/Footer.test.tsx
@@ -2,9 +2,9 @@ import { render, screen } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { Footer } from './Footer'
 import * as footerHooks from './footer.hooks'
-import { EServiceIds } from '@I18n/common/services/types'
-import { ELegalPageSlugs } from '@I18n/common/legalArea/types'
-import type { TIconName } from '@Types/icons'
+import { ServiceIds } from '@I18n/common/services/types'
+import { LegalPageSlugs } from '@I18n/common/legalArea/types'
+import type { IconName } from '@Types/icons'
 
 vi.mock('./footer.hooks')
 
@@ -34,25 +34,25 @@ const mockFooterData = {
   itemsInformation: {
     services: [
       {
-        id: EServiceIds.WEB_PAGES_DEVELOPMENT,
+        id: ServiceIds.WEB_PAGES_DEVELOPMENT,
         title: 'Web Development',
         slug: '/services/web',
-        icon: 'RiCodeSSlashLine' as TIconName,
+        icon: 'RiCodeSSlashLine' as IconName,
         shortDescription: 'Web development services',
         description: 'Full web development description'
       },
       {
-        id: EServiceIds.MOBILE_APPS,
+        id: ServiceIds.MOBILE_APPS,
         title: 'Mobile Apps',
         slug: '/services/mobile',
-        icon: 'RiSmartphoneLine' as TIconName,
+        icon: 'RiSmartphoneLine' as IconName,
         shortDescription: 'Mobile app services',
         description: 'Full mobile app description'
       }
     ],
     legalArea: [
       {
-        id: ELegalPageSlugs.PRIVACY_POLICY,
+        id: LegalPageSlugs.PRIVACY_POLICY,
         slug: '/privacy',
         title: 'Privacy Policy',
         shortDescription: 'Privacy policy description',
@@ -61,7 +61,7 @@ const mockFooterData = {
         showInFooter: true
       },
       {
-        id: ELegalPageSlugs.TERMS_AND_CONDITIONS,
+        id: LegalPageSlugs.TERMS_AND_CONDITIONS,
         slug: '/terms',
         title: 'Terms of Service',
         shortDescription: 'Terms description',
@@ -80,13 +80,13 @@ const mockFooterData = {
     ],
     socialMedia: [
       {
-        icon: 'RiFacebookFill' as TIconName,
+        icon: 'RiFacebookFill' as IconName,
         name: 'Facebook',
         url: 'https://facebook.com',
         active: true
       },
       {
-        icon: 'RiTwitterFill' as TIconName,
+        icon: 'RiTwitterFill' as IconName,
         name: 'Twitter',
         url: 'https://twitter.com',
         active: true

--- a/src/libs/components/molecules/Footer/ItemFooter.tsx
+++ b/src/libs/components/molecules/Footer/ItemFooter.tsx
@@ -8,7 +8,7 @@ interface ItemFooterProps {
   className?: string
 }
 
-interface ILinkFooterProps {
+interface LinkFooterProps {
   children: ReactNode
   className?: string
   href?: string
@@ -37,7 +37,7 @@ export const LinkFooter = ({
   href,
   rel,
   target
-}: ILinkFooterProps) => (
+}: LinkFooterProps) => (
   <Link
     target={target}
     rel={rel}

--- a/src/libs/components/molecules/Header/Header.test.tsx
+++ b/src/libs/components/molecules/Header/Header.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { Header, BgHeader } from './Header'
 import * as headerHooks from './header.hooks'
 import { HeaderProvider } from '@Context/HeaderContext'
-import type { TIconName } from '@Types/icons'
+import type { IconName } from '@Types/icons'
 
 vi.mock('next/link', () => ({
   default: ({
@@ -31,13 +31,13 @@ const mockHeaderData = {
   isSolid: false,
   socialMedia: [
     {
-      icon: 'RiFacebookFill' as TIconName,
+      icon: 'RiFacebookFill' as IconName,
       name: 'Facebook',
       url: 'https://facebook.com',
       active: true
     },
     {
-      icon: 'RiTwitterFill' as TIconName,
+      icon: 'RiTwitterFill' as IconName,
       name: 'Twitter',
       url: 'https://twitter.com',
       active: true

--- a/src/libs/components/molecules/ItemHeroSection/ItemHeroSection.tsx
+++ b/src/libs/components/molecules/ItemHeroSection/ItemHeroSection.tsx
@@ -1,14 +1,14 @@
 import { Container, LinkButton, ParallaxImage } from '@Components/atoms'
 import { uuid } from '@Helpers/uuid'
-import { type ILinkButtonProps } from '@Types/buttonProps'
+import { type LinkButtonProps } from '@Types/buttonProps'
 import clsx from 'clsx'
 import { type StaticImageData } from 'next/image'
 
-interface IItemHeroSectionProps {
+interface ItemHeroSectionProps {
   heroImage: StaticImageData
   title: string
   description: string
-  controlActions?: ILinkButtonProps[]
+  controlActions?: LinkButtonProps[]
 }
 
 export const ItemHeroSection = ({
@@ -16,7 +16,7 @@ export const ItemHeroSection = ({
   title,
   description,
   controlActions = []
-}: IItemHeroSectionProps) => (
+}: ItemHeroSectionProps) => (
   <div className={clsx('bg-slate-950 relative', 'md:bg-white')}>
     <Container
       className={clsx(

--- a/src/libs/components/molecules/LayoutScroll/LayoutScroll.tsx
+++ b/src/libs/components/molecules/LayoutScroll/LayoutScroll.tsx
@@ -6,11 +6,11 @@ import clsx from 'clsx'
 import { BgHeader } from '../Header'
 import { useLayoutScroll } from './layoutScroll.hooks'
 
-interface ILayoutScrollProps {
+interface LayoutScrollProps {
   children: ReactNode
 }
 
-export function LayoutScroll({ children }: Readonly<ILayoutScrollProps>) {
+export function LayoutScroll({ children }: Readonly<LayoutScrollProps>) {
   const { lenisRef } = useLayoutScroll()
 
   return (

--- a/src/libs/components/molecules/Menu/Menu.test.tsx
+++ b/src/libs/components/molecules/Menu/Menu.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { Menu } from './Menu'
 import * as menuHooks from './menu.hooks'
 import { HeaderProvider } from '@Context/HeaderContext'
-import { EPages } from '@Types/pages'
+import { Pages } from '@Types/pages'
 
 const renderWithProvider = (ui: React.ReactElement) =>
   render(<HeaderProvider>{ui}</HeaderProvider>)
@@ -56,14 +56,14 @@ vi.mock('./menu.hooks')
 const mockMenuData = {
   toggleMenu: false,
   menuList: [
-    { id: EPages.HOME, name: 'Home', slug: '/' },
+    { id: Pages.HOME, name: 'Home', slug: '/' },
     {
-      id: EPages.SERVICES,
+      id: Pages.SERVICES,
       name: 'Services',
       slug: '/services'
     },
     {
-      id: EPages.ABOUT,
+      id: Pages.ABOUT,
       name: 'About',
       slug: '/about'
     }

--- a/src/libs/components/molecules/Menu/menu.hooks.ts
+++ b/src/libs/components/molecules/Menu/menu.hooks.ts
@@ -1,6 +1,6 @@
 import { PAGES_INFORMATION } from '@Constants/pages'
 import { useHeaderContext } from '@Context/headerContext.hooks'
-import type { IInformationPage } from '@Types/pages'
+import type { InformationPage } from '@Types/pages'
 import { type Variants } from 'motion'
 
 export const useMenu = () => {
@@ -54,7 +54,7 @@ export const useMenu = () => {
     }
   }
 
-  const menuList: IInformationPage[] = Object.values(PAGES_INFORMATION).map(
+  const menuList: InformationPage[] = Object.values(PAGES_INFORMATION).map(
     page => page.es
   )
 

--- a/src/libs/components/molecules/Slider/Slider.tsx
+++ b/src/libs/components/molecules/Slider/Slider.tsx
@@ -1,13 +1,13 @@
 'use client'
 
 import { Splide, SplideSlide, SplideTrack } from '@splidejs/react-splide'
-import type { ISliderProps } from './slider.types'
+import type { SliderProps } from './slider.types'
 import { uuid } from '@Helpers/uuid'
 import { NextButton, PrevButton } from './SliderArrowButton'
 import clsx from 'clsx'
 import type { SplideProps } from '@splidejs/react-splide'
 
-export const Slider = ({ children, options }: ISliderProps) => {
+export const Slider = ({ children, options }: SliderProps) => {
   const optionsWithDefaults: SplideProps['options'] = {
     classes: {
       pagination: 'splide__pagination flex gap-2 mt-4 justify-center'

--- a/src/libs/components/molecules/Slider/SliderArrowButton.tsx
+++ b/src/libs/components/molecules/Slider/SliderArrowButton.tsx
@@ -1,12 +1,8 @@
 import clsx from 'clsx'
 import { IconComponent } from '@Components/atoms'
-import type { TPropType } from './slider.types'
+import type { PropType } from './slider.types'
 
-export const PrevButton = ({
-  children,
-  className,
-  ...restProps
-}: TPropType) => (
+export const PrevButton = ({ children, className, ...restProps }: PropType) => (
   <button
     type="button"
     {...restProps}
@@ -20,11 +16,7 @@ export const PrevButton = ({
   </button>
 )
 
-export const NextButton = ({
-  children,
-  className,
-  ...restProps
-}: TPropType) => (
+export const NextButton = ({ children, className, ...restProps }: PropType) => (
   <button
     type="button"
     {...restProps}

--- a/src/libs/components/molecules/Slider/SliderDotButton.tsx
+++ b/src/libs/components/molecules/Slider/SliderDotButton.tsx
@@ -1,8 +1,8 @@
 import { IconComponent } from '@Components/atoms'
 import clsx from 'clsx'
-import type { TDotButtonPropType } from './slider.types'
+import type { DotButtonPropType } from './slider.types'
 
-export const DotButton = ({ isSelected, ...restProps }: TDotButtonPropType) => (
+export const DotButton = ({ isSelected, ...restProps }: DotButtonPropType) => (
   <button
     type="button"
     {...restProps}

--- a/src/libs/components/molecules/Slider/slider.types.ts
+++ b/src/libs/components/molecules/Slider/slider.types.ts
@@ -1,18 +1,18 @@
 import type { SplideProps } from '@splidejs/react-splide'
 import type { ComponentPropsWithRef, ReactNode } from 'react'
 
-export interface ISliderProps {
+export interface SliderProps {
   options?: SplideProps['options']
   children: ReactNode | ReactNode[]
 }
 
-export type TPropType = ComponentPropsWithRef<'button'>
+export type PropType = ComponentPropsWithRef<'button'>
 
-export type TDotButtonPropType = TPropType & {
+export type DotButtonPropType = PropType & {
   isSelected: boolean
 }
 
-export type TUseDotButtonType = {
+export type UseDotButtonType = {
   selectedIndex: number
   scrollSnaps: number[]
   onDotButtonClick: (index: number) => void

--- a/src/libs/components/molecules/Testimonials/TestimonialsItem.tsx
+++ b/src/libs/components/molecules/Testimonials/TestimonialsItem.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import type { ITestimonialsItemProps } from './testimonials.types'
+import type { TestimonialsItemProps } from './testimonials.types'
 import { Avatar, Card, Divider, IconComponent } from '@Components/atoms'
 import { uuid } from '@Helpers/uuid'
 import clsx from 'clsx'
@@ -10,7 +10,7 @@ export const TestimonialsItem = ({
   content,
   avatar,
   starRating
-}: ITestimonialsItemProps) => (
+}: TestimonialsItemProps) => (
   <div className="w-full py-5 px-3 flex flex-col items-center">
     <Card className="max-w-80 w-[98%] h-full min-w-75">
       <div className="flex flex-col gap-6">

--- a/src/libs/components/molecules/Testimonials/testimonials.types.ts
+++ b/src/libs/components/molecules/Testimonials/testimonials.types.ts
@@ -1,6 +1,6 @@
 import type { StaticImageData } from 'next/image'
 
-export interface ITestimonialsItemProps {
+export interface TestimonialsItemProps {
   author: string
   role: string
   content: string

--- a/src/libs/constants/clients.ts
+++ b/src/libs/constants/clients.ts
@@ -10,18 +10,18 @@ import {
   RkPower,
   TentacionesGourmet
 } from '@Components/atoms'
-import { type ISvgProps } from '@Types/svg'
+import { type SvgProps } from '@Types/svg'
 import { type ReactNode } from 'react'
 
-interface IClient {
+interface Client {
   id: string
   name: string
   best?: boolean
   url: string
-  logo: (params: ISvgProps) => ReactNode
+  logo: (params: SvgProps) => ReactNode
 }
 
-export const CLIENTS: IClient[] = [
+export const CLIENTS: Client[] = [
   {
     id: 'tentaciones-gourmet',
     name: 'Tentaciones Gourmet',

--- a/src/libs/constants/languages.ts
+++ b/src/libs/constants/languages.ts
@@ -1,4 +1,4 @@
-import type { TLanguage } from '@Types/languages'
+import type { Language } from '@Types/languages'
 
 export const ESP = 'es'
 export const ENG = 'en'
@@ -24,7 +24,7 @@ export const SUPPORTED_LANGUAGES = [
   RUS
 ] as const
 
-export const LANGUAGE_LABELS: Record<TLanguage, string> = {
+export const LANGUAGE_LABELS: Record<Language, string> = {
   [ESP]: 'Español',
   [ENG]: 'English',
   [DEU]: 'Deutsch',

--- a/src/libs/constants/pages.ts
+++ b/src/libs/constants/pages.ts
@@ -1,6 +1,6 @@
 import { informationPage } from '@I18n/pages/home'
-import { EPages } from '@Types/pages'
+import { Pages } from '@Types/pages'
 
 export const PAGES_INFORMATION = {
-  [EPages.HOME]: informationPage
+  [Pages.HOME]: informationPage
 }

--- a/src/libs/constants/socialMedia.ts
+++ b/src/libs/constants/socialMedia.ts
@@ -1,13 +1,13 @@
-import { type TIconName } from '@Types/icons'
+import { type IconName } from '@Types/icons'
 
-interface ISocialMedia {
+interface SocialMedia {
   active?: boolean
-  icon: TIconName
+  icon: IconName
   name: string
   url: string
 }
 
-export const SOCIAL_MEDIA: ISocialMedia[] = [
+export const SOCIAL_MEDIA: SocialMedia[] = [
   {
     active: true,
     icon: 'RiFacebookFill',

--- a/src/libs/context/HeaderContext.tsx
+++ b/src/libs/context/HeaderContext.tsx
@@ -3,11 +3,11 @@
 import { type ReactNode, useCallback, useMemo, useState } from 'react'
 import { HeaderContext } from './headerContext.hooks'
 
-interface IHeaderProviderProps {
+interface HeaderProviderProps {
   children: ReactNode
 }
 
-export const HeaderProvider = ({ children }: IHeaderProviderProps) => {
+export const HeaderProvider = ({ children }: HeaderProviderProps) => {
   const [headerState, setHeaderState] = useState({
     isSolid: false,
     toggleMenu: false

--- a/src/libs/context/headerContext.hooks.ts
+++ b/src/libs/context/headerContext.hooks.ts
@@ -1,13 +1,13 @@
 import { createContext, useContext } from 'react'
 
-interface IHeaderContext {
+interface HeaderContextValue {
   isSolid: boolean
   toggleMenu: boolean
   setIsSolid: (value: boolean) => void
   setToggleMenu: (value: boolean) => void
 }
 
-export const HeaderContext = createContext<IHeaderContext | undefined>(
+export const HeaderContext = createContext<HeaderContextValue | undefined>(
   undefined
 )
 

--- a/src/libs/i18n/common/footer/locales/es.ts
+++ b/src/libs/i18n/common/footer/locales/es.ts
@@ -1,6 +1,6 @@
-import type { IFooterStructure } from '../types'
+import type { FooterStructure } from '../types'
 
-export const footerEs: IFooterStructure = {
+export const footerEs: FooterStructure = {
   textFooter:
     'Somos una empresa dedicada a la creación de software con un enfoque en la calidad.',
   servicesTitle: 'Servicios',

--- a/src/libs/i18n/common/footer/types.ts
+++ b/src/libs/i18n/common/footer/types.ts
@@ -1,4 +1,4 @@
-export interface IFooterStructure {
+export interface FooterStructure {
   textFooter: string
   servicesTitle: string
   legalAreaTitle: string

--- a/src/libs/i18n/common/legalArea/constants.ts
+++ b/src/libs/i18n/common/legalArea/constants.ts
@@ -1,4 +1,4 @@
-import { ELegalPageSlugs } from './types'
+import { LegalPageSlugs, type LegalPage } from './types'
 import {
   formatAccessibilityStatement,
   formatComplaintsBook,
@@ -9,40 +9,46 @@ import {
   formatTermsAndConditions
 } from './formatters'
 
+type LegalPageConfigItem = {
+  lastUpdated: string
+  showInFooter: boolean
+  formatter: (page: LegalPage) => LegalPage
+}
+
 export const LEGAL_PAGES_CONFIG = {
-  [ELegalPageSlugs.ACCESSIBILITY_STATEMENT]: {
+  [LegalPageSlugs.ACCESSIBILITY_STATEMENT]: {
     lastUpdated: '2025-10-01T00:00:00.000Z',
     showInFooter: true,
     formatter: formatAccessibilityStatement
   },
-  [ELegalPageSlugs.COMPLAINTS_BOOK]: {
+  [LegalPageSlugs.COMPLAINTS_BOOK]: {
     lastUpdated: '2025-09-15T00:00:00.000Z',
     showInFooter: false,
     formatter: formatComplaintsBook
   },
-  [ELegalPageSlugs.COOKIES_POLICY]: {
+  [LegalPageSlugs.COOKIES_POLICY]: {
     lastUpdated: '2025-09-10T00:00:00.000Z',
     showInFooter: true,
     formatter: formatCookiesPolicy
   },
-  [ELegalPageSlugs.DATA_PROTECTION]: {
+  [LegalPageSlugs.DATA_PROTECTION]: {
     lastUpdated: '2025-08-28T00:00:00.000Z',
     showInFooter: true,
     formatter: formatDataProtection
   },
-  [ELegalPageSlugs.LEGAL_NOTICE]: {
+  [LegalPageSlugs.LEGAL_NOTICE]: {
     lastUpdated: '2025-07-30T00:00:00.000Z',
     showInFooter: true,
     formatter: formatLegalNotice
   },
-  [ELegalPageSlugs.PRIVACY_POLICY]: {
+  [LegalPageSlugs.PRIVACY_POLICY]: {
     lastUpdated: '2025-09-05T00:00:00.000Z',
     showInFooter: true,
     formatter: formatPrivacyPolicy
   },
-  [ELegalPageSlugs.TERMS_AND_CONDITIONS]: {
+  [LegalPageSlugs.TERMS_AND_CONDITIONS]: {
     lastUpdated: '2025-10-20T00:00:00.000Z',
     showInFooter: true,
     formatter: formatTermsAndConditions
   }
-} as const
+} satisfies Record<LegalPageSlugs, LegalPageConfigItem>

--- a/src/libs/i18n/common/legalArea/formatters.ts
+++ b/src/libs/i18n/common/legalArea/formatters.ts
@@ -1,34 +1,29 @@
-import type { ILegalPage, ILegalPageItem } from './types'
-import { LEGAL_PAGES_CONFIG } from './constants'
-import { ELegalPageSlugs } from './types'
+import type { LegalPage } from './types'
 
-const baseFormat = (
-  page: ILegalPage,
-  slug: ELegalPageSlugs
-): ILegalPageItem => ({
-  ...page,
-  lastUpdated: LEGAL_PAGES_CONFIG[slug].lastUpdated,
-  showInFooter: LEGAL_PAGES_CONFIG[slug].showInFooter
+export const formatAccessibilityStatement = (page: LegalPage): LegalPage => ({
+  ...page
 })
 
-export const formatAccessibilityStatement = (
-  page: ILegalPage
-): ILegalPageItem => baseFormat(page, ELegalPageSlugs.ACCESSIBILITY_STATEMENT)
+export const formatComplaintsBook = (page: LegalPage): LegalPage => ({
+  ...page
+})
 
-export const formatComplaintsBook = (page: ILegalPage): ILegalPageItem =>
-  baseFormat(page, ELegalPageSlugs.COMPLAINTS_BOOK)
+export const formatCookiesPolicy = (page: LegalPage): LegalPage => ({
+  ...page
+})
 
-export const formatCookiesPolicy = (page: ILegalPage): ILegalPageItem =>
-  baseFormat(page, ELegalPageSlugs.COOKIES_POLICY)
+export const formatDataProtection = (page: LegalPage): LegalPage => ({
+  ...page
+})
 
-export const formatDataProtection = (page: ILegalPage): ILegalPageItem =>
-  baseFormat(page, ELegalPageSlugs.DATA_PROTECTION)
+export const formatLegalNotice = (page: LegalPage): LegalPage => ({
+  ...page
+})
 
-export const formatLegalNotice = (page: ILegalPage): ILegalPageItem =>
-  baseFormat(page, ELegalPageSlugs.LEGAL_NOTICE)
+export const formatPrivacyPolicy = (page: LegalPage): LegalPage => ({
+  ...page
+})
 
-export const formatPrivacyPolicy = (page: ILegalPage): ILegalPageItem =>
-  baseFormat(page, ELegalPageSlugs.PRIVACY_POLICY)
-
-export const formatTermsAndConditions = (page: ILegalPage): ILegalPageItem =>
-  baseFormat(page, ELegalPageSlugs.TERMS_AND_CONDITIONS)
+export const formatTermsAndConditions = (page: LegalPage): LegalPage => ({
+  ...page
+})

--- a/src/libs/i18n/common/legalArea/helpers.ts
+++ b/src/libs/i18n/common/legalArea/helpers.ts
@@ -1,9 +1,7 @@
 import { LEGAL_PAGES_CONFIG } from './constants'
-import type { ILegalPage, ILegalPageItem } from './types'
+import type { LegalPage, LegalPageItem } from './types'
 
-export const formatLegalPages = (
-  legalPages: ILegalPage[]
-): ILegalPageItem[] => {
+export const formatLegalPages = (legalPages: LegalPage[]): LegalPageItem[] => {
   return legalPages.map(page => {
     const config = LEGAL_PAGES_CONFIG[page.id]
     return {

--- a/src/libs/i18n/common/legalArea/locales/es/accessibilityStatement.ts
+++ b/src/libs/i18n/common/legalArea/locales/es/accessibilityStatement.ts
@@ -1,7 +1,7 @@
-import { ELegalPageSlugs, type ILegalPage } from '../../types'
+import { LegalPageSlugs, type LegalPage } from '../../types'
 
-export const accessibilityStatementEs: ILegalPage = {
-  id: ELegalPageSlugs.ACCESSIBILITY_STATEMENT,
+export const accessibilityStatementEs: LegalPage = {
+  id: LegalPageSlugs.ACCESSIBILITY_STATEMENT,
   title: 'Declaración de Accesibilidad',
   slug: 'accesibilidad',
   shortDescription: 'Compromiso con la accesibilidad web',

--- a/src/libs/i18n/common/legalArea/locales/es/complaintsBook.ts
+++ b/src/libs/i18n/common/legalArea/locales/es/complaintsBook.ts
@@ -1,7 +1,7 @@
-import { ELegalPageSlugs, type ILegalPage } from '../../types'
+import { LegalPageSlugs, type LegalPage } from '../../types'
 
-export const complaintsBookEs: ILegalPage = {
-  id: ELegalPageSlugs.COMPLAINTS_BOOK,
+export const complaintsBookEs: LegalPage = {
+  id: LegalPageSlugs.COMPLAINTS_BOOK,
   title: 'Libro de Reclamaciones',
   slug: 'libro-de-reclamaciones',
   shortDescription: 'Accede a nuestro libro de reclamaciones',

--- a/src/libs/i18n/common/legalArea/locales/es/cookiesPolicy.ts
+++ b/src/libs/i18n/common/legalArea/locales/es/cookiesPolicy.ts
@@ -1,7 +1,7 @@
-import { ELegalPageSlugs, type ILegalPage } from '../../types'
+import { LegalPageSlugs, type LegalPage } from '../../types'
 
-export const cookiesPolicyEs: ILegalPage = {
-  id: ELegalPageSlugs.COOKIES_POLICY,
+export const cookiesPolicyEs: LegalPage = {
+  id: LegalPageSlugs.COOKIES_POLICY,
   title: 'Política de Cookies',
   slug: 'politica-de-cookies',
   shortDescription: 'Conoce nuestra política de uso de cookies',

--- a/src/libs/i18n/common/legalArea/locales/es/dataProtection.ts
+++ b/src/libs/i18n/common/legalArea/locales/es/dataProtection.ts
@@ -1,7 +1,7 @@
-import { ELegalPageSlugs, type ILegalPage } from '../../types'
+import { LegalPageSlugs, type LegalPage } from '../../types'
 
-export const dataProtectionEs: ILegalPage = {
-  id: ELegalPageSlugs.DATA_PROTECTION,
+export const dataProtectionEs: LegalPage = {
+  id: LegalPageSlugs.DATA_PROTECTION,
   title: 'Protección de Datos',
   slug: 'proteccion-de-datos',
   shortDescription: 'Información sobre la protección de datos',

--- a/src/libs/i18n/common/legalArea/locales/es/index.ts
+++ b/src/libs/i18n/common/legalArea/locales/es/index.ts
@@ -6,9 +6,9 @@ import { cookiesPolicyEs } from './cookiesPolicy'
 import { legalNoticeEs } from './legalNotice'
 import { accessibilityStatementEs } from './accessibilityStatement'
 
-import type { ILegalPage } from '../../types'
+import type { LegalPage } from '../../types'
 
-export const legalPagesEs: ILegalPage[] = [
+export const legalPagesEs: LegalPage[] = [
   complaintsBookEs,
   termsAndConditionsEs,
   privacyPolicyEs,

--- a/src/libs/i18n/common/legalArea/locales/es/legalNotice.ts
+++ b/src/libs/i18n/common/legalArea/locales/es/legalNotice.ts
@@ -1,7 +1,7 @@
-import { ELegalPageSlugs, type ILegalPage } from '../../types'
+import { LegalPageSlugs, type LegalPage } from '../../types'
 
-export const legalNoticeEs: ILegalPage = {
-  id: ELegalPageSlugs.LEGAL_NOTICE,
+export const legalNoticeEs: LegalPage = {
+  id: LegalPageSlugs.LEGAL_NOTICE,
   title: 'Aviso Legal',
   slug: 'aviso-legal',
   shortDescription: 'Información legal y de propiedad del sitio',

--- a/src/libs/i18n/common/legalArea/locales/es/privacyPolicy.ts
+++ b/src/libs/i18n/common/legalArea/locales/es/privacyPolicy.ts
@@ -1,7 +1,7 @@
-import { ELegalPageSlugs, type ILegalPage } from '../../types'
+import { LegalPageSlugs, type LegalPage } from '../../types'
 
-export const privacyPolicyEs: ILegalPage = {
-  id: ELegalPageSlugs.PRIVACY_POLICY,
+export const privacyPolicyEs: LegalPage = {
+  id: LegalPageSlugs.PRIVACY_POLICY,
   title: 'Política de Privacidad',
   slug: 'politica-de-privacidad',
   shortDescription: 'Conoce nuestra política de privacidad',

--- a/src/libs/i18n/common/legalArea/locales/es/termsAndConditions.ts
+++ b/src/libs/i18n/common/legalArea/locales/es/termsAndConditions.ts
@@ -1,7 +1,7 @@
-import { ELegalPageSlugs, type ILegalPage } from '../../types'
+import { LegalPageSlugs, type LegalPage } from '../../types'
 
-export const termsAndConditionsEs: ILegalPage = {
-  id: ELegalPageSlugs.TERMS_AND_CONDITIONS,
+export const termsAndConditionsEs: LegalPage = {
+  id: LegalPageSlugs.TERMS_AND_CONDITIONS,
   title: 'Términos y Condiciones',
   slug: 'terminos-y-condiciones',
   shortDescription: 'Consulta nuestros términos y condiciones',

--- a/src/libs/i18n/common/legalArea/types.ts
+++ b/src/libs/i18n/common/legalArea/types.ts
@@ -1,17 +1,17 @@
-export interface ILegalPage {
-  id: ELegalPageSlugs
+export interface LegalPage {
+  id: LegalPageSlugs
   title: string
   slug: string
   shortDescription: string
   description: string
 }
 
-export interface ILegalPageItem extends ILegalPage {
+export interface LegalPageItem extends LegalPage {
   lastUpdated: string
   showInFooter: boolean
 }
 
-export enum ELegalPageSlugs {
+export enum LegalPageSlugs {
   ACCESSIBILITY_STATEMENT = 'accessibility-statement',
   COMPLAINTS_BOOK = 'complaints-book',
   COOKIES_POLICY = 'cookies-policy',

--- a/src/libs/i18n/common/metrics/constants.ts
+++ b/src/libs/i18n/common/metrics/constants.ts
@@ -1,15 +1,15 @@
-import { ECompanyMetricId } from './types'
+import { CompanyMetricId } from './types'
 
 export const SUFFIX_COMPANY_METRICS = {
-  [ECompanyMetricId.YEARS_EXPERIENCE]: '+',
-  [ECompanyMetricId.PROJECTS_COMPLETED]: '+',
-  [ECompanyMetricId.SATISFIED_CLIENTS]: '%',
-  [ECompanyMetricId.COMMITMENT_TO_QUALITY]: '%'
+  [CompanyMetricId.YEARS_EXPERIENCE]: '+',
+  [CompanyMetricId.PROJECTS_COMPLETED]: '+',
+  [CompanyMetricId.SATISFIED_CLIENTS]: '%',
+  [CompanyMetricId.COMMITMENT_TO_QUALITY]: '%'
 }
 
 export const VALUES_COMPANY_METRICS = {
-  [ECompanyMetricId.YEARS_EXPERIENCE]: 8,
-  [ECompanyMetricId.PROJECTS_COMPLETED]: 150,
-  [ECompanyMetricId.SATISFIED_CLIENTS]: 100,
-  [ECompanyMetricId.COMMITMENT_TO_QUALITY]: 100
+  [CompanyMetricId.YEARS_EXPERIENCE]: 8,
+  [CompanyMetricId.PROJECTS_COMPLETED]: 150,
+  [CompanyMetricId.SATISFIED_CLIENTS]: 100,
+  [CompanyMetricId.COMMITMENT_TO_QUALITY]: 100
 }

--- a/src/libs/i18n/common/metrics/helpers.ts
+++ b/src/libs/i18n/common/metrics/helpers.ts
@@ -1,9 +1,9 @@
 import { SUFFIX_COMPANY_METRICS, VALUES_COMPANY_METRICS } from './constants'
-import type { ICompanyMetric, ICompanyMetricsItem } from './types'
+import type { CompanyMetric, CompanyMetricsItem } from './types'
 
 export const formatCompanyMetrics = (
-  metrics: ICompanyMetric[]
-): ICompanyMetricsItem[] =>
+  metrics: CompanyMetric[]
+): CompanyMetricsItem[] =>
   metrics.map(metric => ({
     ...metric,
     suffix: SUFFIX_COMPANY_METRICS[metric.id],

--- a/src/libs/i18n/common/metrics/locales/es.ts
+++ b/src/libs/i18n/common/metrics/locales/es.ts
@@ -1,20 +1,20 @@
-import { ECompanyMetricId, type ICompanyMetric } from '../types'
+import { CompanyMetricId, type CompanyMetric } from '../types'
 
-export const companyMetricsEs: ICompanyMetric[] = [
+export const companyMetricsEs: CompanyMetric[] = [
   {
-    id: ECompanyMetricId.YEARS_EXPERIENCE,
+    id: CompanyMetricId.YEARS_EXPERIENCE,
     label: 'Años de experiencia'
   },
   {
-    id: ECompanyMetricId.PROJECTS_COMPLETED,
+    id: CompanyMetricId.PROJECTS_COMPLETED,
     label: 'Proyectos completados'
   },
   {
-    id: ECompanyMetricId.SATISFIED_CLIENTS,
+    id: CompanyMetricId.SATISFIED_CLIENTS,
     label: 'Clientes satisfechos'
   },
   {
-    id: ECompanyMetricId.COMMITMENT_TO_QUALITY,
+    id: CompanyMetricId.COMMITMENT_TO_QUALITY,
     label: 'Compromiso con la calidad'
   }
 ]

--- a/src/libs/i18n/common/metrics/types.ts
+++ b/src/libs/i18n/common/metrics/types.ts
@@ -1,14 +1,14 @@
-export interface ICompanyMetric {
-  id: ECompanyMetricId
+export interface CompanyMetric {
+  id: CompanyMetricId
   label: string
 }
 
-export interface ICompanyMetricsItem extends ICompanyMetric {
+export interface CompanyMetricsItem extends CompanyMetric {
   value: number
   suffix: string
 }
 
-export enum ECompanyMetricId {
+export enum CompanyMetricId {
   YEARS_EXPERIENCE = 'yearsExperience',
   PROJECTS_COMPLETED = 'projectsCompleted',
   SATISFIED_CLIENTS = 'satisfiedClients',

--- a/src/libs/i18n/common/services/constants.ts
+++ b/src/libs/i18n/common/services/constants.ts
@@ -1,12 +1,12 @@
-import { EServiceIds, type TIconServices } from './types'
+import { ServiceIds, type IconServices } from './types'
 
-export const ICON_SERVICES: TIconServices = {
-  [EServiceIds.WEB_PAGES_DEVELOPMENT]: 'RiGlobalLine',
-  [EServiceIds.SOFTWARE_DEVELOPMENT]: 'RiCodeFill',
-  [EServiceIds.E_COMMERCE]: 'RiShoppingCartLine',
-  [EServiceIds.MOBILE_APPS]: 'RiSmartphoneLine',
-  [EServiceIds.DIGITAL_MARKETING]: 'RiMegaphoneLine',
-  [EServiceIds.UX_UI_DESIGN]: 'RiPaletteLine',
-  [EServiceIds.SEO]: 'RiSearchLine',
-  [EServiceIds.EMAIL_MARKETING]: 'RiMailLine'
+export const ICON_SERVICES: IconServices = {
+  [ServiceIds.WEB_PAGES_DEVELOPMENT]: 'RiGlobalLine',
+  [ServiceIds.SOFTWARE_DEVELOPMENT]: 'RiCodeFill',
+  [ServiceIds.E_COMMERCE]: 'RiShoppingCartLine',
+  [ServiceIds.MOBILE_APPS]: 'RiSmartphoneLine',
+  [ServiceIds.DIGITAL_MARKETING]: 'RiMegaphoneLine',
+  [ServiceIds.UX_UI_DESIGN]: 'RiPaletteLine',
+  [ServiceIds.SEO]: 'RiSearchLine',
+  [ServiceIds.EMAIL_MARKETING]: 'RiMailLine'
 }

--- a/src/libs/i18n/common/services/helpers.ts
+++ b/src/libs/i18n/common/services/helpers.ts
@@ -1,7 +1,7 @@
 import { ICON_SERVICES } from './constants'
-import type { IService, IServiceItem } from './types'
+import type { Service, ServiceItem } from './types'
 
-export const formatServices = (services: IService[]): IServiceItem[] =>
+export const formatServices = (services: Service[]): ServiceItem[] =>
   services.map(service => ({
     ...service,
     icon: ICON_SERVICES[service.id]

--- a/src/libs/i18n/common/services/locales/es.ts
+++ b/src/libs/i18n/common/services/locales/es.ts
@@ -1,8 +1,8 @@
-import { EServiceIds, type IService } from '../types'
+import { ServiceIds, type Service } from '../types'
 
-export const servicesEs: IService[] = [
+export const servicesEs: Service[] = [
   {
-    id: EServiceIds.WEB_PAGES_DEVELOPMENT,
+    id: ServiceIds.WEB_PAGES_DEVELOPMENT,
     title: 'Desarrollo de Páginas Web',
     slug: 'desarrollo-de-paginas-web',
     shortDescription: 'Sitios web modernos y rápidos',
@@ -10,7 +10,7 @@ export const servicesEs: IService[] = [
       'Diseñamos y desarrollamos sitios web atractivos y funcionales que se adaptan a todos los dispositivos, garantizando una experiencia de usuario óptima y un rendimiento excepcional.'
   },
   {
-    id: EServiceIds.SOFTWARE_DEVELOPMENT,
+    id: ServiceIds.SOFTWARE_DEVELOPMENT,
     title: 'Desarrollo de Software',
     slug: 'desarrollo-de-software',
     shortDescription: 'Soluciones personalizadas que impulsan tu negocio',
@@ -18,7 +18,7 @@ export const servicesEs: IService[] = [
       'Creamos aplicaciones a medida que se adaptan a las necesidades específicas de tu empresa, utilizando las últimas tecnologías para garantizar rendimiento y escalabilidad.'
   },
   {
-    id: EServiceIds.E_COMMERCE,
+    id: ServiceIds.E_COMMERCE,
     title: 'E-commerce',
     slug: 'e-commerce',
     shortDescription: 'Tiendas online optimizadas para conversión',
@@ -26,7 +26,7 @@ export const servicesEs: IService[] = [
       'Desarrollamos plataformas de comercio electrónico intuitivas y seguras que ofrecen una experiencia de usuario excepcional, aumentando las ventas y la fidelización de clientes.'
   },
   {
-    id: EServiceIds.MOBILE_APPS,
+    id: ServiceIds.MOBILE_APPS,
     title: 'Apps Móviles',
     slug: 'apps-moviles',
     shortDescription: 'Aplicaciones nativas y multiplataforma',
@@ -34,7 +34,7 @@ export const servicesEs: IService[] = [
       'Diseñamos y desarrollamos aplicaciones móviles para iOS y Android, enfocándonos en la usabilidad y el rendimiento para maximizar el alcance y la satisfacción del usuario.'
   },
   {
-    id: EServiceIds.DIGITAL_MARKETING,
+    id: ServiceIds.DIGITAL_MARKETING,
     title: 'Marketing Digital',
     slug: 'marketing-digital',
     shortDescription: 'Estrategias que generan resultados',
@@ -42,7 +42,7 @@ export const servicesEs: IService[] = [
       'Implementamos campañas de marketing digital efectivas que incluyen SEO, SEM, redes sociales y email marketing para aumentar la visibilidad de tu marca y atraer a tu público objetivo.'
   },
   {
-    id: EServiceIds.UX_UI_DESIGN,
+    id: ServiceIds.UX_UI_DESIGN,
     title: 'Diseño UX/UI',
     slug: 'ux-ui',
     shortDescription: 'Diseños intuitivos y atractivos',
@@ -50,7 +50,7 @@ export const servicesEs: IService[] = [
       'Creamos interfaces de usuario atractivas y funcionales que mejoran la experiencia del usuario, aumentando la satisfacción y la retención de clientes.'
   },
   {
-    id: EServiceIds.SEO,
+    id: ServiceIds.SEO,
     title: 'SEO',
     slug: 'seo',
     shortDescription: 'Posicionamiento web efectivo',
@@ -58,7 +58,7 @@ export const servicesEs: IService[] = [
       'Optimizamos tu sitio web para los motores de búsqueda, mejorando su ranking y aumentando el tráfico orgánico mediante técnicas de SEO on-page y off-page.'
   },
   {
-    id: EServiceIds.EMAIL_MARKETING,
+    id: ServiceIds.EMAIL_MARKETING,
     title: 'Email Marketing',
     slug: 'email-marketing',
     shortDescription: 'Campañas que conectan con tu audiencia',

--- a/src/libs/i18n/common/services/types.ts
+++ b/src/libs/i18n/common/services/types.ts
@@ -1,18 +1,18 @@
-import { type TIconName } from '@Types/icons'
+import { type IconName } from '@Types/icons'
 
-export interface IService {
-  id: EServiceIds
+export interface Service {
+  id: ServiceIds
   title: string
   slug: string
   shortDescription: string
   description: string
 }
 
-export interface IServiceItem extends IService {
-  icon: TIconName
+export interface ServiceItem extends Service {
+  icon: IconName
 }
 
-export enum EServiceIds {
+export enum ServiceIds {
   WEB_PAGES_DEVELOPMENT = 'web-pages-development',
   SOFTWARE_DEVELOPMENT = 'software-development',
   E_COMMERCE = 'e-commerce',
@@ -23,6 +23,6 @@ export enum EServiceIds {
   EMAIL_MARKETING = 'email-marketing'
 }
 
-export type TIconServices = {
-  [key in EServiceIds]: TIconName
+export type IconServices = {
+  [key in ServiceIds]: IconName
 }

--- a/src/libs/i18n/common/testimonials/constants.ts
+++ b/src/libs/i18n/common/testimonials/constants.ts
@@ -1,8 +1,8 @@
 import { ESP } from '@Constants/languages'
-import { ETestimonialIds, type TTestimonialsInformation } from './types'
+import { TestimonialIds, type TestimonialsInformation } from './types'
 
-export const TESTIMONIALS_INFORMATION: TTestimonialsInformation = {
-  [ETestimonialIds.JOHN_DOE]: {
+export const TESTIMONIALS_INFORMATION: TestimonialsInformation = {
+  [TestimonialIds.JOHN_DOE]: {
     avatar: '/images/testimonials/john_doe.jpg',
     score: 2,
     originalLanguage: ESP

--- a/src/libs/i18n/common/testimonials/helpers.ts
+++ b/src/libs/i18n/common/testimonials/helpers.ts
@@ -1,9 +1,9 @@
 import { TESTIMONIALS_INFORMATION } from './constants'
-import type { ITestimony, TTestimonyItem } from './types'
+import type { Testimony, TestimonyItem } from './types'
 
 export const formatTestimonials = (
-  testimonials: ITestimony[]
-): TTestimonyItem[] =>
+  testimonials: Testimony[]
+): TestimonyItem[] =>
   testimonials.map(testimonial => {
     const localizedInfo = TESTIMONIALS_INFORMATION[testimonial.name]
 

--- a/src/libs/i18n/common/testimonials/locales/es.ts
+++ b/src/libs/i18n/common/testimonials/locales/es.ts
@@ -1,6 +1,6 @@
-import { type ITestimony } from '../types'
+import { type Testimony } from '../types'
 
-export const testimonialsEs: ITestimony[] = [
+export const testimonialsEs: Testimony[] = [
   // {
   //   name: ETestimonialIds.JOHN_DOE,
   //   position: 'CEO de Tech Solutions',

--- a/src/libs/i18n/common/testimonials/types.ts
+++ b/src/libs/i18n/common/testimonials/types.ts
@@ -1,24 +1,24 @@
-import type { TLanguage } from '@Types/languages'
-import type { TRange } from '@Types/range'
+import type { Language } from '@Types/languages'
+import type { Range } from '@Types/range'
 
-export interface ITestimony {
-  name: ETestimonialIds
+export interface Testimony {
+  name: TestimonialIds
   position: string
   testimonial: string
 }
 
-export interface ITestimonyLocalized {
+export interface TestimonyLocalized {
   avatar?: string
-  score: TRange<1, 5>
-  originalLanguage: TLanguage
+  score: Range<1, 5>
+  originalLanguage: Language
 }
 
-export type TTestimonyItem = ITestimony & ITestimonyLocalized
+export type TestimonyItem = Testimony & TestimonyLocalized
 
-export enum ETestimonialIds {
+export enum TestimonialIds {
   JOHN_DOE = 'John Doe'
 }
 
-export type TTestimonialsInformation = {
-  [key in ETestimonialIds]: ITestimonyLocalized
+export type TestimonialsInformation = {
+  [key in TestimonialIds]: TestimonyLocalized
 }

--- a/src/libs/i18n/pages/home/constants.ts
+++ b/src/libs/i18n/pages/home/constants.ts
@@ -1,6 +1,6 @@
-import { EHeroSectionId, type THeroSectionIcons } from './types'
+import { EHeroSectionId, type HeroSectionIcons } from './types'
 
-export const heroSectionIcons: THeroSectionIcons = {
+export const heroSectionIcons: HeroSectionIcons = {
   [EHeroSectionId.PROJECTS_SLIDE]: {
     firstControlIcon: 'RiArrowRightLine',
     secondControlIcon: 'RiBriefcase3Fill'

--- a/src/libs/i18n/pages/home/locales/es.ts
+++ b/src/libs/i18n/pages/home/locales/es.ts
@@ -1,19 +1,19 @@
-import { EPages, type IInformationPage } from '@Types/pages'
+import { Pages, type InformationPage } from '@Types/pages'
 import {
   EHeroSectionId,
-  type IHeroSection,
-  type IMetricsSection,
-  type IServicesSection,
-  type ITestimonialsSection
+  type HeroSection,
+  type MetricsSection,
+  type ServicesSection,
+  type TestimonialsSection
 } from '../types'
 
-export const informationPageEs: IInformationPage = {
-  id: EPages.HOME,
+export const informationPageEs: InformationPage = {
+  id: Pages.HOME,
   name: 'Inicio',
   slug: '/'
 }
 
-export const heroSectionEs: IHeroSection[] = [
+export const heroSectionEs: HeroSection[] = [
   {
     id: EHeroSectionId.PROJECTS_SLIDE,
     title: 'Transformamos tus ideas en realidad digital',
@@ -32,7 +32,7 @@ export const heroSectionEs: IHeroSection[] = [
   }
 ]
 
-export const servicesSectionEs: IServicesSection = {
+export const servicesSectionEs: ServicesSection = {
   title: 'Nuestros Servicios',
   description:
     'Ofrecemos soluciones completas para todas tus necesidades digitales.',
@@ -42,13 +42,13 @@ export const servicesSectionEs: IServicesSection = {
   }
 }
 
-export const metricsSectionEs: IMetricsSection = {
+export const metricsSectionEs: MetricsSection = {
   title: 'Resultados que hablan por sí mismos',
   description:
     'Nuestra trayectoria está respaldada por números que demuestran nuestro compromiso con la excelencia y la satisfacción del cliente.'
 }
 
-export const testimonialsEs: ITestimonialsSection = {
+export const testimonialsEs: TestimonialsSection = {
   title: 'Lo que dicen nuestros clientes',
   description: 'La confianza de nuestros clientes es nuestro mayor logro.'
 }

--- a/src/libs/i18n/pages/home/types.ts
+++ b/src/libs/i18n/pages/home/types.ts
@@ -1,25 +1,25 @@
-import { type ILinkButtonProps } from '@Types/buttonProps'
-import type { TIconName } from '@Types/icons'
+import { type LinkButtonProps } from '@Types/buttonProps'
+import type { IconName } from '@Types/icons'
 
-export interface IHeroSection {
+export interface HeroSection {
   id: EHeroSectionId
   title: string
   description: string
-  controlActions: ILinkButtonProps[]
+  controlActions: LinkButtonProps[]
 }
 
-export interface IServicesSection {
+export interface ServicesSection {
   title: string
   description: string
-  controlAction: ILinkButtonProps
+  controlAction: LinkButtonProps
 }
 
-export interface IMetricsSection {
+export interface MetricsSection {
   title: string
   description: string
 }
 
-export interface ITestimonialsSection {
+export interface TestimonialsSection {
   title: string
   description: string
 }
@@ -28,9 +28,9 @@ export enum EHeroSectionId {
   PROJECTS_SLIDE = 'PROJECTS_SLIDE'
 }
 
-export type THeroSectionIcons = {
+export type HeroSectionIcons = {
   [key in EHeroSectionId]: {
-    firstControlIcon?: TIconName
-    secondControlIcon?: TIconName
+    firstControlIcon?: IconName
+    secondControlIcon?: IconName
   }
 }

--- a/src/libs/i18n/pages/home/utils.ts
+++ b/src/libs/i18n/pages/home/utils.ts
@@ -1,9 +1,7 @@
 import { heroSectionIcons } from './constants'
-import type { IHeroSection, IServicesSection } from './types'
+import type { HeroSection, ServicesSection } from './types'
 
-export const formatHeroSection = (
-  heroSection: IHeroSection[]
-): IHeroSection[] =>
+export const formatHeroSection = (heroSection: HeroSection[]): HeroSection[] =>
   heroSection.map(section => ({
     ...section,
     controlActions: section.controlActions.map((action, index) => {
@@ -22,12 +20,12 @@ export const formatHeroSection = (
   }))
 
 export const formatServicesSection = (
-  ServicesSection: IServicesSection
-): IServicesSection => {
+  servicesSection: ServicesSection
+): ServicesSection => {
   return {
-    ...ServicesSection,
+    ...servicesSection,
     controlAction: {
-      ...ServicesSection.controlAction,
+      ...servicesSection.controlAction,
       icon: 'RiArrowRightLine'
     }
   }

--- a/src/libs/types/buttonProps.ts
+++ b/src/libs/types/buttonProps.ts
@@ -3,23 +3,23 @@ import type {
   ButtonHTMLAttributes,
   ReactNode
 } from 'react'
-import { type TIconName } from './icons'
+import { type IconName } from './icons'
 import { type LinkProps } from 'next/link'
 
-export interface IButtonBaseProps {
+export interface ButtonBaseProps {
   variant?: 'primary' | 'secondary' | undefined
   size?: 'small' | 'medium' | 'large' | undefined
-  icon?: TIconName | undefined
+  icon?: IconName | undefined
 }
 
-export interface IButtonProps
-  extends ButtonHTMLAttributes<HTMLButtonElement>, IButtonBaseProps {
+export interface ButtonProps
+  extends ButtonHTMLAttributes<HTMLButtonElement>, ButtonBaseProps {
   children: ReactNode
 }
 
-export interface ILinkButtonProps
+export interface LinkButtonProps
   extends
-    IButtonBaseProps,
+    ButtonBaseProps,
     Omit<AnchorHTMLAttributes<HTMLAnchorElement>, keyof LinkProps>,
     LinkProps {
   href: string

--- a/src/libs/types/icons.ts
+++ b/src/libs/types/icons.ts
@@ -1,7 +1,8 @@
 import * as RemixIcons from '@remixicon/react'
 
-export type TIconName = keyof typeof RemixIcons
-export interface IIconProps {
-  icon: TIconName
+export type IconName = keyof typeof RemixIcons
+
+export interface IconProps {
+  icon: IconName
   className?: string
 }

--- a/src/libs/types/languages.ts
+++ b/src/libs/types/languages.ts
@@ -1,3 +1,3 @@
 import type { SUPPORTED_LANGUAGES } from '@Constants/languages'
 
-export type TLanguage = (typeof SUPPORTED_LANGUAGES)[number]
+export type Language = (typeof SUPPORTED_LANGUAGES)[number]

--- a/src/libs/types/pages.ts
+++ b/src/libs/types/pages.ts
@@ -1,4 +1,4 @@
-export enum EPages {
+export enum Pages {
   HOME = 'home',
   ABOUT = 'about',
   SERVICES = 'services',
@@ -7,8 +7,8 @@ export enum EPages {
   CONTACT = 'contact'
 }
 
-export interface IInformationPage {
-  id: EPages
+export interface InformationPage {
+  id: Pages
   name: string
   slug: string
 }

--- a/src/libs/types/range.ts
+++ b/src/libs/types/range.ts
@@ -1,11 +1,11 @@
-export type TRange<
+export type Range<
   Start extends number,
   End extends number,
   Result extends unknown[] = [],
   Acc extends number = never
 > = Result['length'] extends End
   ? Acc | End
-  : TRange<
+  : Range<
       Start,
       End,
       [...Result, unknown],

--- a/src/libs/types/svg.ts
+++ b/src/libs/types/svg.ts
@@ -1,9 +1,9 @@
 import type { SVGProps } from 'react'
 
-export interface ISvgProps extends SVGProps<SVGSVGElement> {
+export interface SvgProps extends SVGProps<SVGSVGElement> {
   isColor?: boolean
 }
 
-export interface ISvgPropsMask extends SVGProps<SVGMaskElement> {
+export interface SvgMaskProps extends SVGProps<SVGMaskElement> {
   isColor?: boolean
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -31,10 +31,10 @@ export default defineConfig({
       ],
       include: ['src/**/*.{ts,tsx}'],
       thresholds: {
-        lines: 70,
-        functions: 70,
-        branches: 70,
-        statements: 70
+        lines: 90,
+        functions: 90,
+        branches: 90,
+        statements: 90
       }
     },
     include: ['**/*.{test,spec}.{ts,tsx}'],


### PR DESCRIPTION
## 🧾 Summary (required)

- **What:** Remove `I*`, `T*`, `E*` type-name prefixes across the repo and update all imports/usages.
- **Why:** Align with TypeScript community conventions and simplify naming consistency.
- **Impact / User-facing:** No intended UX change; internal refactor only.

---

## 🧩 Type of change

- [ ] feat (new feature)
- [ ] fix (bug fix)
- [x] refactor (no functional change)
- [ ] style (formatting, lint, UI polish)
- [ ] perf (performance improvement)
- [ ] docs (documentation)
- [ ] test (tests only)
- [ ] build (build/dependencies)
- [ ] ci (pipelines/automation)
- [ ] chore (internal/maintenance)
- [ ] revert

---

## 🧭 Scope

- [x] web
- [x] ui
- [x] i18n
- [x] config

---

## ✅ Changes (required)

| Area | Path(s) | Change | Risk | Notes |
| ---- | ------- | ------ | ---- | ----- |
| types | `src/libs/types/**` | Rename exported types/enums/interfaces | low | Pure rename + import updates |
| i18n | `src/libs/i18n/**` | Update domain types/enums + helpers/locales | low | Includes legalArea config typing fix |
| ui | `src/libs/components/**` | Update props/types in components & tests | low | No runtime behavior intended |
| repo | `.github/PULL_REQUEST_TEMPLATE.md` | Add PR template | low | Adds contributor guidance |

---

## 🧪 How to test (required)

### Steps

1. Run validations locally.
2. Optionally run the app and smoke-check core pages.

### Commands

| Check | Command | Result |
| --- | --- | --- |
| Typecheck + lint | `pnpm validate` | ✅ |
| Tests | `pnpm test` | ✅ |
| Coverage (min 90%) | `pnpm test:coverage` | (optional) |

### Coverage summary

N/A (not collected in this run).

---

## ⚠️ Breaking Changes

- [x] No

---

## ✅ Checklist

- [x] PR title follows Conventional Commits
- [ ] Issue reference included (`#ID`) when applicable (recommended)
- [x] Code follows project standards
- [x] TypeScript strict mode respected
- [x] No `any` types introduced
- [x] No `console.*` statements or `debugger` left in code
- [x] No empty `catch {}` blocks
- [x] Lint and tests are passing
- [x] Documentation updated (if needed)
